### PR TITLE
Add warning note about isClient and isServer

### DIFF
--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -88,6 +88,8 @@ The extend is called twice, one time for the server bundle, and one time for the
 1. webpack config object,
 2. object with the following keys (all boolean): `isDev`, `isClient`, `isServer`, `loaders`.
 
+*note: The `isClient` and `isServer` keys in extend are separate from the keys available in context. `process.client` and `process.server` are undefined at this point and cannot be used.*
+
 Example (`nuxt.config.js`):
 
 ```js


### PR DESCRIPTION
Add short warning note about `isClient`/`isServer` in build extend to deter developers from thinking it is deprecated and should be replaced with `process.client`/`process.server`, which would return undefined and therefore cannot be used.

There appearrs to be a large amount of misinformation about this property, leading to a lot of incorrect configurations that *appear* to be correct because replacing `isClient` with `process.client` will disable linting, making it appear as if there are no errors, when the reality is they have just disabled linting.